### PR TITLE
Refactor FiniteStateMachine to use a done flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,7 @@ The algorithm, and examples for implementing the FSMs and then iterating over th
 
 The first step is to clone the repository created by GitHub Classroom when the assignment was accepted in a sensible directory. In the vscode terminal, `git clone <URL>` where `<URL>` is the one from GitHub Classroom after accepting the assignment. Or open a new vscode window, select _Clone Git Repository_, and paste the link they get when they hover over the "<> Code ▼" and copy the url
 
-There is no need to install any vscode extensions. These should all still be present and active from the previous project. You do need to create the virtual environment, install the package, and install pre-commit. For a reminder to how that is done, see on [learningsuite.byu.edu](https://learningsuite.byu.edu) _Content_ &rarr; _Projects_ &rarr; _Projects Cheat Sheet_
-
-  * Create a virtual environment
-  * Install the package in edit mode: `pip install --editable ".[dev]"`
-  * Install pre-commit: `pre-commit install`
-
-The above should result in a `project1` executable that is run from the command line in an integrated terminal. As before, be sure the integrated terminal is in the virtual environment
-
-### WARNING
-
-  * Be sure that the `conda` environment is not active when setting up the project. It's active when there is a `(base)` annotation next to the terminal prompt. The `conda deactivate` command will exit that environment.
-  * Be sure the Python version is at least 3.11 -- `python --version`.
-  * Open the project folder in vscode when working on the project, and not a folder above it or below it, otherwise the paths for the pass-off tests will not work -- the common error is _"no project2 module found"_.
-  * Be sure that vscode is using the virtual environment in the project folder: choose `Python Select Interpreter` from the command pallette and select the Python in the `.venv` folder -- its usually the first option if vscode opened that folder as the workspace.
+There is no need to install any vscode extensions. These should all still be present and active from the previous project. You do need to create the virtual environment and install the package.For a reminder to how that is done, see on [learningsuite.byu.edu](https://learningsuite.byu.edu) _Content_ &rarr; _Projects_ &rarr; _Projects Cheat Sheet_. When done there should be a `project1` executable that is run from the command line in an integrated terminal. As before, be sure the integrated terminal is in the virtual environment
 
 ## Files
 
@@ -146,25 +133,37 @@ The `test_lexer.py` includes tests for the lexer that are suitable for the three
 
 The entry point for the auto-grader and the `project1` command. See the docstrings for details.
 
-## Where to start
+## Project Requirements
 
-Here is the suggested order for Project 1:
+This project is going to have you write code on your own, generate code using AI, and use two new tools to improve code quality. Each of these requirements is explained separately.
 
-1. Run the tests in `test_lexer.py` -- they should fail
-1. Implement the `lexer` function in `lexer.py` -- `test_lexer.py` should pass when the implementation is done
-1. Repeat until all the FSMs are implemented
+### Code you must write on your own
 
-    1. Choose an unimplemented FSM and write the accept and reject tests for it in `test_fsm.py`
-    1. Run the new tests -- they should fail
-    1. Create the state diagram (or state table) for the FSM to implement -- **we advise you to not skip this step**
-    1. Implement the FSM from the state diagram (or state table)-- done when the new tests pass
-    1. Write a new test in `test_lexer.py` that includes the newly implemented FSM
-    1. Run the new test -- it should fail
-    1. Add the new FSM to the `lexer` function -- done when the new test passes
+1. Implement the `lexer` function in `lexer.py`. We have already written tests in `test_lexer.py` for the `COLON`, `EOF`, and `WHITESPACE` tokens that currently fail since `lexer` is not implemented yet. Use these tests to guide your implementation of the `lexer` function and indicate when you have a working solution.
 
-1. Run the pass-off tests -- debug as needed
+1. Implement a `Comma` state machine using the `Colon` state machine as a pattern.
 
-### Testing reminder
+1. Write a pair of tests for a `String` state machine. One test should accept. One test should reject. Use the examples in `test_fsm.py` to guide your tests.
+
+1. Implement the `String` state machine by generalizing the pattern from the `Comma` and `Colon` machines. It should pass the tests from the previous step when complete.
+
+1. Implement the `Comment` state machine. Writing tests similar to the tests for `String` is recommended but not required.
+
+### Code you must write with AI
+
+Use generative AI to write the state machines for the rest of the tokens. Feel free to have it add test cases for each machine to `test_fsm.py` and to the test function in `test_lexer.py` if you so desire. For the generated code, write a docstring explaining how you prompted the AI to complete this task and how you determined the quality, and correctness, of the generated code.
+
+### Code Quality Tools
+
+Run the following tools on your code and correct any reported issues:
+
+1. `ruff check` --- detects and reports code smells
+1. `ruff format` --- enforces consistent formatting
+1. `mypy src/project1/*.py` --- type checks the files
+
+The `ruff` and `mypy` tools are integrated into `vscode` with the extensions you installed from Project 0. The _Problems_ pain reports code smells from `ruff` and type errors from `mypy` on opened files and is helpful for correcting issues.
+
+## Testing Review
 
 The testing pane is super convenient for running, and debugging tests. The integrated terminal is also super helpful. The `-k` flag is the easiest to find and choose a test since it uses matching. Try it out.
 
@@ -190,14 +189,17 @@ $ pytest -k project1.project1.project1
 
 ## Pass-off and Submission
 
-The minimum standard for this project is **bucket 80**. That means that if all the tests pass in all buckets up to and including bucket 80, then the next project can be started safely.
+The minimum standard for this project is **bucket 80**. That means that if all the tests pass in all buckets up to and including bucket 80, then the next project can be started safely. You can run each bucket from the testing pane or with `pytest` on the command line. Passing everything up to and including `test_passoff_80.py` is the minimum requirement to move on to the next project.
 
-The Project 1 submission follows that of Project 0:
+The Project 1 submission:
 
   * Commit your solution on the master branch
   * Push the commit to GitHub -- that should trigger the auto-grader
-  * Goto [learningsuite.byu.edu](https://learningsuite.byu.edu) at _Assignments_ &rarr; _Projects_ &rarr; _Project 1_ to submit your GitHub ID and Project 1 URL for grading.
-  * Goto the Project 1 URL, find the green checkmark or red x, and click it to confirm the auto-grader score matches the pass-off results from your system.
+  * Goto [learningsuite.byu.edu](https://learningsuite.byu.edu) at _Assignments_ &rarr; _Projects_ &rarr; _Project 1_ to submit the following:
+    1. your GitHub ID and Project 1 URL for grading.
+    1. your docstring discussing how you prompted the AI to generate the code and how you determined the quality and correctness of the code.
+    1. a screen shot showing no issues with `mypy`, `ruff check`, and `ruff format`.
+  * Confirm on the GitHub Actions pane that the pass-off tests passed, or alternatively, goto the Project 1 URL, find the green checkmark or red x, and click it to confirm the auto-grader score matches the pass-off results from your system.
 
 ### Branches
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ project1 = "project1.project1:project1cli"
 dev = [
   "pytest",
   "mypy",
+  "ruff",
   "pre-commit",
 ]
 

--- a/src/project1/fsm.py
+++ b/src/project1/fsm.py
@@ -2,33 +2,44 @@
 
 The finite state machine (FSM) is abstracted by the `FiniteStateMachine` class.
 The function `run_fsm(fsm, input_string)` runs the indicated `fsm` until it
-accepts or rejects to return the resulting characters read and token.
+is "done" and then checks if it accepts or rejects to return the resulting characters
+read and token.
+
+TL;DR returning `True` from a State when given an input means that the FSM is
+done and it is safe to check if the resulting state is an accept or reject state
+to determine if it reads a prefix of the input.
+
+An FSM normally reads until there are no more characters left in the input
+and then it checks what state it is in to determine whether it accepts or rejects.
+In our application to lexical analysis we want the FSM to stop reading as soon as it
+determines it is done reading and knows if it will accept or reject. As such, the
+end of input is marked when the FSM signals it is "done" by returning `True` when
+computing the next state. At that point, it is safe to check if the FSM is in an
+accept or reject state to know whether or not it reads a prefix of the input and
+how many characters are in that prefix that it can read.
 """
 
+from io import StringIO
 from typing import Callable
 
 from project1.token import Token
 
-State = Callable[[int, str], "StateAndOutput"]
+State = Callable[[str], tuple[bool, "State"]]
 """
-`State` is a function that takes two inputs and returns a new state with the
-new output. The `int` input is the number of characters read. The `str`
-input is the character to read. The output is the new state and the new
-number of characters read.
-"""
-StateAndOutput = tuple[State, int]
-"""
-The `State` is the new state resulting from the input while the `int` is the
-new output resulting from the input.
+`State` is a function that takes the character to read as a `str` and returns
+a `bool` signifying whether or not it is done reading and the next `State`
+(`State` : `I` -> `bool` times `State`).
 """
 
 
 def run_fsm(fsm: "FiniteStateMachine", input_string: str) -> tuple[int, Token]:
     """Run an FSM and return the number of characters read with the token.
 
-    Run the passed in FSM until it accepts or rejects. The output is captured
-    on each state transition and passed as input with the next character. It returns
-    the number or character read and the resulting token.
+    Run the FSM until it accepts or rejects while counting the number of
+    characters read until the FSM is done. Once the FSM is done, check to see
+    if it accepts or rejects the input. The return value is a tuple of the total
+    number of characters read and the resulting token if the FSM accepts.
+    A reject always reads no characters.
 
     Args:
 
@@ -48,41 +59,34 @@ def run_fsm(fsm: "FiniteStateMachine", input_string: str) -> tuple[int, Token]:
         >>> "number_chars_read = {} token = {}".format(number_chars_read, str(token))
         'number_chars_read = 1 token = (COLON,":",0)'
     """
-    current_state: State = fsm.initial_state
-    next_state: State
+    stream: StringIO = StringIO(input_string)
+    done, state = fsm.initial_state(stream.read(1))
+    num_chars_read: int = 0
 
-    output_num_chars_read: int = 0
+    while not done:
+        num_chars_read = num_chars_read + 1
+        done, state = state(stream.read(1))
 
-    input_num_chars_read: int = 0
-    input_char: str = ""
+    if FiniteStateMachine.is_reject(state):
+        num_chars_read = 0
+    elif FiniteStateMachine.is_accept(state):
+        pass
+    else:
+        raise AssertionError(f"ERROR: unexpected {state!r}")
 
-    number_of_chars = len(input_string)
-    for i in range(0, number_of_chars + 1):
-        input_num_chars_read = output_num_chars_read
-        input_char = input_string[i] if i < number_of_chars else ""
-
-        next_state, output_num_chars_read = current_state(
-            input_num_chars_read, input_char
-        )
-        if next_state in {
-            FiniteStateMachine.s_accept,
-            FiniteStateMachine.s_reject,
-        }:
-            break
-
-        current_state = next_state
-
-    value = input_string[:output_num_chars_read]
-    return (output_num_chars_read, fsm.token(value))
+    value = input_string[:num_chars_read]
+    return num_chars_read, fsm.token(value)
 
 
 class FiniteStateMachine:
     """Base class for the finite state machine (FSM) abstraction.
 
-    The base class defines the accept and reject states. The reject state
-    will always return zero characters read. Once accept/reject, then always
-    accept/reject. The output does not change once in these states. The
-    `token` function should be overridden in each subclass.
+    The base class defines how to detect accept and reject states
+    based on the name of the functions defining the states.
+    It also provides an "always done and accept" state along with
+    an "always done and reject" state.
+
+    Note: The `token` function should be overridden in each subclass.
 
     Attributes:
         initial_state (State): The initial state for this FSM.
@@ -101,25 +105,54 @@ class FiniteStateMachine:
     def token(self, value: str) -> Token:
         """Return the token produced by this FSM
 
-        NOTE: this method must be overridden in any subclass as it defaults to UNDEFINED
+        NOTE: this method must be overridden in every subclass. as
+        the base class always returns Token.UNDEFINED
 
         Args:
             value: The value associated with this `Token`.
 
         Returns:
-            Token.undefined: The method must be overridden in subclasses.
+            token: The token generated by the FSM when it accepts.
         """
         return Token.undefined(value)
 
     @staticmethod
-    def s_accept(input_chars_read: int, input_char: str) -> StateAndOutput:
-        """Accept sync state -- once accept always accept."""
-        return FiniteStateMachine.s_accept, input_chars_read
+    def is_accept(state: State) -> bool:
+        """Return true if and only if `state` is an accept state
+
+        Any `State` with `accept` in its name is an accept state.
+
+        Args:
+            state: The state being considered.
+
+        Return:
+            True if and only if `state` has accept in its name.
+        """
+        return "accept" in state.__name__
 
     @staticmethod
-    def s_reject(input_chars_read: int, input_char: str) -> StateAndOutput:
-        """Reject sync state -- once reject always reject."""
-        return FiniteStateMachine.s_reject, input_chars_read
+    def is_reject(state: State) -> bool:
+        """Return true if and only if `state` is an accept state
+
+        Any `State` with `accept` in its name is an accept state.
+
+        Args:
+            state: The state being considered.
+
+        Return:
+            True if and only if `state` has accept in its name.
+        """
+        return "reject" in state.__name__
+
+    @staticmethod
+    def s_is_done_accept(input_char: str) -> tuple[bool, State]:
+        """Always done and always accept regardless of `input_char`"""
+        return True, FiniteStateMachine.s_is_done_accept
+
+    @staticmethod
+    def s_is_done_reject(input_char: str) -> tuple[bool, State]:
+        """Always done and always reject regardless of `input_char`"""
+        return True, FiniteStateMachine.s_is_done_reject
 
 
 class Colon(FiniteStateMachine):
@@ -129,15 +162,11 @@ class Colon(FiniteStateMachine):
     def token(self, value: str) -> Token:
         """Create a token of type COLON.
 
-        NOTE: the match statement is for mypy as it ensures that mypy is able to statically
-        prove that `value` is ":" when calling `Token.colon(value)`. Follow the pattern for
-        other keyword FSMs.
-
         Args:
             value: The characters read by the FSM.
 
         Returns:
-            Token.colon: iff what is read is a ":" otherwise Token.undefined -- both use `value` for the token.
+            Token.COLON: iff what is read is a ":" otherwise Token.UNDEFINED.
         """
         match value:
             case ":":
@@ -146,11 +175,11 @@ class Colon(FiniteStateMachine):
                 return super().token(value)
 
     @staticmethod
-    def s_0(input_chars_read: int, input_char: str) -> StateAndOutput:
+    def s_0(input_char: str) -> tuple[bool, State]:
         if input_char == ":":
-            return FiniteStateMachine.s_accept, input_chars_read + 1
+            return False, FiniteStateMachine.s_is_done_accept
         else:
-            return FiniteStateMachine.s_reject, 0
+            return True, FiniteStateMachine.s_is_done_reject
 
 
 class Eof(FiniteStateMachine):
@@ -158,6 +187,14 @@ class Eof(FiniteStateMachine):
         super().__init__(Eof.s_0)
 
     def token(self, value: str) -> Token:
+        """Create a token of type EOF.
+
+        Args:
+            value: The characters read by the FSM.
+
+        Returns:
+            Token.EOF: iff what is read is an empty string otherwise Token.UNDEFINED.
+        """
         match value:
             case "":
                 return Token.eof(value)
@@ -165,11 +202,11 @@ class Eof(FiniteStateMachine):
                 return super().token(value)
 
     @staticmethod
-    def s_0(input_chars_read: int, input_char: str) -> StateAndOutput:
+    def s_0(input_char: str) -> tuple[bool, State]:
         if input_char == "":
-            return FiniteStateMachine.s_accept, input_chars_read + 1
+            return False, FiniteStateMachine.s_is_done_accept
         else:
-            return FiniteStateMachine.s_reject, 0
+            return True, FiniteStateMachine.s_is_done_reject
 
 
 class WhiteSpace(FiniteStateMachine):
@@ -177,13 +214,28 @@ class WhiteSpace(FiniteStateMachine):
         super().__init__(WhiteSpace.s_0)
 
     def token(self, value: str) -> Token:
-        return Token.whitespace(value)
+        """Create a token of type WHITESPACE.
+
+        Args:
+            value: The characters read by the FSM.
+
+        Returns:
+            Token.WHITESPACE: iff what is read is whitespace otherwise Token.UNDEFINED.
+        """
+        if value.isspace():
+            return Token.whitespace(value)
+        return super().token(value)
 
     @staticmethod
-    def s_0(input_chars_read: int, input_char: str) -> StateAndOutput:
+    def s_0(input_char: str) -> tuple[bool, State]:
         if input_char in [" ", "\t", "\r", "\n"]:
-            return WhiteSpace.s_0, input_chars_read + 1
-        elif input_chars_read > 0:
-            return FiniteStateMachine.s_accept, input_chars_read
+            return False, WhiteSpace.s_accept
         else:
-            return FiniteStateMachine.s_reject, 0
+            return True, FiniteStateMachine.s_is_done_reject
+
+    @staticmethod
+    def s_accept(input_char: str) -> tuple[bool, State]:
+        if input_char in [" ", "\t", "\r", "\n"]:
+            return False, WhiteSpace.s_accept
+        else:
+            return True, FiniteStateMachine.s_is_done_accept

--- a/src/project1/fsm.py
+++ b/src/project1/fsm.py
@@ -92,8 +92,6 @@ class FiniteStateMachine:
         initial_state (State): The initial state for this FSM.
     """
 
-    __slots__ = ["initial_state"]
-
     def __init__(self, initial_state: State) -> None:
         """Initialize the FSM with its initial state
 

--- a/src/project1/fsm.py
+++ b/src/project1/fsm.py
@@ -132,17 +132,17 @@ class FiniteStateMachine:
 
     @staticmethod
     def is_reject(state: State) -> bool:
-        """Return true if and only if `state` is an accept state
+        """Return true if and only if `state` is not an accept state
 
-        Any `State` with `accept` in its name is an accept state.
+        Any `State` that is not an accept state.
 
         Args:
             state: The state being considered.
 
         Return:
-            True if and only if `state` has accept in its name.
+            True if and only if `state` is not an accept state
         """
-        return "reject" in state.__name__
+        return not FiniteStateMachine.is_accept(state)
 
     @staticmethod
     def s_is_done_accept(input_char: str) -> tuple[bool, State]:

--- a/src/project1/lexer.py
+++ b/src/project1/lexer.py
@@ -53,11 +53,7 @@ def lexer(input_string: str) -> Iterator[Token]:
     Yields:
         token: The current token resulting from the string.
     """
-    fsms: list[FiniteStateMachine] = [Colon(), Eof(), WhiteSpace()]
-    hidden: list[TokenType] = ["WHITESPACE"]
-
-    # TODO: remove the `print` statements since they are only here for ruff
-    print(fsms)
-    print(hidden)
+    fsms: list[FiniteStateMachine] = [Colon(), Eof(), WhiteSpace()]  # noqa: F841
+    hidden: list[TokenType] = ["WHITESPACE"]  # noqa: F841
 
     raise NotImplementedError

--- a/src/project1/token.py
+++ b/src/project1/token.py
@@ -66,8 +66,6 @@ class Token:
         line_num (int): The line number associated with the token -- where it starts in the input.
     """
 
-    __slots__ = ["token_type", "value", "line_num"]
-
     def __init__(self, token_type: TokenType, value: str, line_num: int = 0) -> None:
         """Initialize a `Token` with its type, value, and line number.
 


### PR DESCRIPTION
A finite state machine now reads until it is "done" at which point the state can be checked to see if it is an accept or reject state. The "done" is signaled when the state transition returns `True` with the next state rather than `False` with the next state.

Justification: the abstract mathematical definition has a different purpose than the actual implementation of the abstraction. The abstract mathematical definition concerns the computation itself with its properties;  whereas, the implementation concerns how that computation should take place on a computing platform. These two concerns are often separate and should only be conflated when both concerns are well served by the abstraction.

In our application of FSMs, trying to get the code and abstract mathematical definition to exactly match is not useful to understanding FSMs as a mathematical concept or writing good code.  I think the solution in this PR is a good compromise. There is a fairly straight line to the math, using the "done" signal, while addressing the separate concerns of implementation as the "done" signals indicates end of input triggering the check for accept or reject.
